### PR TITLE
대시보드 페이지 UI 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
+        "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-separator": "^1.1.7",
@@ -1053,6 +1054,32 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
+      "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -1445,6 +1472,23 @@
       "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
+      "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
+      "dependencies": {
+        "use-sync-external-store": "^1.5.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2032,7 +2076,7 @@
       "version": "19.1.6",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
       "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2042,7 +2086,7 @@
       "version": "19.1.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.5.tgz",
       "integrity": "sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -3162,7 +3206,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -7194,6 +7238,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
+    "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-separator": "^1.1.7",

--- a/src/app/(after-login)/dashboard/page.tsx
+++ b/src/app/(after-login)/dashboard/page.tsx
@@ -1,11 +1,17 @@
 import { DashboardHeader } from '@/components/dashboard/DashboardHeader';
 import WelcomeSection from '@/components/dashboard/WelcomeSection';
+import { QuickActions } from '@/components/dashboard/QuickActions';
+import { RecentPlaylists } from '@/components/dashboard/RecentPlaylists';
+import { DashboardBottomSection } from '@/components/dashboard/DashboardBottomSection';
 
 export default function Page() {
   return (
-    <div className='space-y-4'>
+    <div className='space-y-8'>
       <DashboardHeader />
       <WelcomeSection />
+      <QuickActions />
+      <RecentPlaylists />
+      <DashboardBottomSection />
     </div>
   );
 }

--- a/src/app/(after-login)/dashboard/page.tsx
+++ b/src/app/(after-login)/dashboard/page.tsx
@@ -1,3 +1,11 @@
+import { DashboardHeader } from '@/components/dashboard/DashboardHeader';
+import WelcomeSection from '@/components/dashboard/WelcomeSection';
+
 export default function Page() {
-  return <div>Dashboard Page</div>;
+  return (
+    <div className='space-y-4'>
+      <DashboardHeader />
+      <WelcomeSection />
+    </div>
+  );
 }

--- a/src/app/(after-login)/dashboard/page.tsx
+++ b/src/app/(after-login)/dashboard/page.tsx
@@ -6,7 +6,7 @@ import { DashboardBottomSection } from '@/components/dashboard/DashboardBottomSe
 
 export default function Page() {
   return (
-    <div className='space-y-8'>
+    <div className='space-y-8 p-4'>
       <DashboardHeader />
       <WelcomeSection />
       <QuickActions />

--- a/src/app/(after-login)/layout.tsx
+++ b/src/app/(after-login)/layout.tsx
@@ -3,23 +3,34 @@ import { MobileNav } from '@/components/dashboard/MobileNav';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import { cookies } from 'next/headers';
 import { PropsWithChildren } from 'react';
+import { createClient } from '@/utils/supabase/server';
+import { UserProvider } from '@/context/user-context';
 
 export default async function Layout({ children }: PropsWithChildren) {
   const cookieStore = await cookies();
   const defaultOpen = cookieStore.get('sidebar_state')?.value === 'true';
 
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const userName = user?.user_metadata?.nickname || user?.email?.split('@')[0] || '사용자';
+
   return (
     <SidebarProvider defaultOpen={defaultOpen}>
-      <div className='flex min-h-screen w-full'>
-        <aside className='sticky top-0 h-screen'>
-          <AppSidebar />
-        </aside>
+      <UserProvider userName={userName}>
+        <div className='flex min-h-screen w-full'>
+          <aside className='sticky top-0 h-screen'>
+            <AppSidebar />
+          </aside>
 
-        <main className='w-full flex-1 overflow-y-auto transition-[padding] duration-200 ease-linear group-data-[state=collapsed]/sidebar-wrapper:pl-[var(--sidebar-width-icon)] md:p-6'>
-          <MobileNav />
-          {children}
-        </main>
-      </div>
+          <main className='w-full flex-1 overflow-y-auto transition-[padding] duration-200 ease-linear group-data-[state=collapsed]/sidebar-wrapper:pl-[var(--sidebar-width-icon)] md:p-6'>
+            <MobileNav />
+            {children}
+          </main>
+        </div>
+      </UserProvider>
     </SidebarProvider>
   );
 }

--- a/src/app/(after-login)/layout.tsx
+++ b/src/app/(after-login)/layout.tsx
@@ -1,5 +1,6 @@
 import AppSidebar from '@/components/app-sidebar/AppSidebar';
-import { SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar';
+import { MobileNav } from '@/components/dashboard/MobileNav';
+import { SidebarProvider } from '@/components/ui/sidebar';
 import { cookies } from 'next/headers';
 import { PropsWithChildren } from 'react';
 
@@ -9,15 +10,13 @@ export default async function Layout({ children }: PropsWithChildren) {
 
   return (
     <SidebarProvider defaultOpen={defaultOpen}>
-      <div className='flex min-h-screen'>
+      <div className='flex min-h-screen w-full'>
         <aside className='sticky top-0 h-screen'>
           <AppSidebar />
         </aside>
 
-        <main className='flex-1 overflow-y-auto p-6 transition-[padding] duration-200 ease-linear group-data-[state=collapsed]/sidebar-wrapper:pl-[var(--sidebar-width-icon)]'>
-          <div className='mb-4 md:hidden'>
-            <SidebarTrigger />
-          </div>
+        <main className='w-full flex-1 overflow-y-auto transition-[padding] duration-200 ease-linear group-data-[state=collapsed]/sidebar-wrapper:pl-[var(--sidebar-width-icon)] md:p-6'>
+          <MobileNav />
           {children}
         </main>
       </div>

--- a/src/components/app-sidebar/AppSidebar.tsx
+++ b/src/components/app-sidebar/AppSidebar.tsx
@@ -10,7 +10,7 @@ export default function AppSidebar() {
   const pathname = usePathname();
 
   return (
-    <Sidebar>
+    <Sidebar className='hidden md:flex'>
       <SidebarHeader className='p-5'>
         <Logo />
       </SidebarHeader>

--- a/src/components/dashboard/DashboardBottomSection.tsx
+++ b/src/components/dashboard/DashboardBottomSection.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import Link from 'next/link';
+
+export function DashboardBottomSection() {
+  return (
+    <Card className='bg-gradient-to-r from-purple-600 to-pink-600 text-white'>
+      <CardContent className='p-8 text-center'>
+        <h3 className='mb-2 text-2xl font-bold'>새로운 플레이리스트 만들기</h3>
+        <p className='mb-6 opacity-90'>AI가 당신만을 위한 완벽한 플레이리스트를 생성합니다</p>
+        <Link href='/create'>
+          <Button size='lg' variant='secondary'>
+            시작하기
+          </Button>
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Bell } from 'lucide-react';
+import Link from 'next/link';
+
+export function DashboardHeader() {
+  return (
+    <div className='hidden items-center justify-between md:flex'>
+      <h1 className='text-2xl font-bold'>Home</h1>
+      <div className='flex items-center gap-2'>
+        <Button variant='ghost' size='icon'>
+          <Bell className='h-5 w-5' />
+        </Button>
+        <Link href='/dashboard/profile'>
+          <Avatar className='cursor-pointer'>
+            <AvatarImage src='/placeholder.svg?height=32&width=32' alt='사용자' />
+            <AvatarFallback />
+          </Avatar>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/MobileNav.tsx
+++ b/src/components/dashboard/MobileNav.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
+import { Menu, Search } from 'lucide-react';
+import { navItems } from '@/constants/navigation';
+import Logo from '../ui/Logo';
+import { CreatePlaylistButton } from '@/components/ui/create-playlist-button';
+
+export function MobileNav() {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <div className='flex items-center justify-between border-b p-4 md:hidden'>
+        <div className='flex items-center gap-2'>
+          <Sheet open={open} onOpenChange={setOpen}>
+            <SheetTrigger asChild>
+              <Button variant='ghost' size='icon'>
+                <Menu className='h-5 w-5' />
+              </Button>
+            </SheetTrigger>
+            <SheetContent side='left' className='w-64 p-0'>
+              <div className='flex h-full flex-col p-4'>
+                <Logo size='md' className='!text-center' />
+
+                <div className='mt-4 space-y-1'>
+                  {navItems.map((item) => (
+                    <Button key={item.url} variant={pathname === item.url ? 'secondary' : 'ghost'} className='w-full justify-start' asChild onClick={() => setOpen(false)}>
+                      <Link href={item.url}>
+                        <item.icon className='mr-2 h-4 w-4' />
+                        {item.title}
+                      </Link>
+                    </Button>
+                  ))}
+                </div>
+
+                <CreatePlaylistButton className='mt-auto mb-4' onClick={() => setOpen(false)} showText isPrimary>
+                  새 플레이리스트
+                </CreatePlaylistButton>
+              </div>
+            </SheetContent>
+          </Sheet>
+
+          <div className='flex items-center gap-2'>
+            <Logo size='sm' className='!text-center' />
+          </div>
+        </div>
+
+        <Button variant='ghost' size='icon' asChild>
+          <Link href='/dashboard/search'>
+            <Search className='h-5 w-5' />
+          </Link>
+        </Button>
+      </div>
+
+      {/* 모바일 하단 네비게이션 */}
+      <div className='bg-background fixed right-0 bottom-0 left-0 z-10 flex justify-around border-t p-2 md:hidden'>
+        {navItems.slice(0, 2).map((item) => (
+          <Button key={item.url} variant={pathname === item.url ? 'secondary' : 'ghost'} size='icon' asChild>
+            <Link href={item.url}>
+              <item.icon className='h-5 w-5' />
+            </Link>
+          </Button>
+        ))}
+
+        <CreatePlaylistButton />
+
+        {navItems.slice(3, 5).map((item) => (
+          <Button key={item.url} variant={pathname === item.url ? 'secondary' : 'ghost'} size='icon' asChild>
+            <Link href={item.url}>
+              <item.icon className='h-5 w-5' />
+            </Link>
+          </Button>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/components/dashboard/QuickActions.tsx
+++ b/src/components/dashboard/QuickActions.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Card, CardContent } from '@/components/ui/card';
+import Link from 'next/link';
+import { quickActions } from '@/constants/quick-actions';
+
+export function QuickActions() {
+  return (
+    <div className='space-y-4'>
+      <h2 className='text-xl font-bold'>빠른 플레이리스트 생성</h2>
+
+      <div className='grid grid-cols-2 gap-4 md:grid-cols-4'>
+        {quickActions.map((action) => (
+          <div key={action.title}>
+            <Link href={action.href}>
+              <Card className='hover:bg-muted/50 cursor-pointer transition-colors'>
+                <CardContent className='flex flex-col items-center justify-center p-4 text-center'>
+                  <div className='bg-primary/10 mb-2 flex h-10 w-10 items-center justify-center rounded-full'>{action.icon}</div>
+                  <p className='text-sm font-medium'>{action.title}</p>
+                </CardContent>
+              </Card>
+            </Link>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/RecentPlaylists.tsx
+++ b/src/components/dashboard/RecentPlaylists.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { ChevronRight } from 'lucide-react';
+import Link from 'next/link';
+
+export function RecentPlaylists() {
+  // 예시 플레이리스트 데이터
+  const playlists = [
+    {
+      id: 1,
+      title: '출근길 플레이리스트',
+      songCount: 12,
+      duration: '45분',
+      tags: ['팝', '2010년대'],
+    },
+    {
+      id: 2,
+      title: '집중할 때 듣는 음악',
+      songCount: 18,
+      duration: '62분',
+      tags: ['일렉트로닉', '인디'],
+    },
+    {
+      id: 3,
+      title: '운동할 때 듣는 음악',
+      songCount: 15,
+      duration: '53분',
+      tags: ['힙합', 'EDM'],
+    },
+  ];
+
+  return (
+    <div className='space-y-4'>
+      <div className='flex items-center justify-between'>
+        <h2 className='text-lg font-medium'>최근 플레이리스트</h2>
+        <Button variant='link' size='sm' asChild>
+          <Link href='/dashboard/playlists'>
+            모두 보기 <ChevronRight className='ml-1 h-4 w-4' />
+          </Link>
+        </Button>
+      </div>
+
+      <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3'>
+        {playlists.map((playlist) => (
+          <div key={playlist.id}>
+            <Link href={`/dashboard/playlists/${playlist.id}`}>
+              <Card className='hover:bg-muted/50 cursor-pointer transition-colors'>
+                <CardContent className='p-4'>
+                  <div className='flex flex-col'>
+                    <div className='mb-3 h-32 w-full rounded-md bg-gradient-to-br from-purple-400 to-pink-400'></div>
+                    <div className='space-y-1'>
+                      <p className='font-medium'>{playlist.title}</p>
+                      <p className='text-muted-foreground text-xs'>
+                        {playlist.songCount}곡 • {playlist.duration}
+                      </p>
+                      <div className='flex gap-1'>
+                        {playlist.tags.map((tag) => (
+                          <Badge key={tag} variant='secondary' className='text-xs'>
+                            {tag}
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/WelcomeSection.tsx
+++ b/src/components/dashboard/WelcomeSection.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Music } from 'lucide-react';
+import { CreatePlaylistButton } from '@/components/ui/create-playlist-button';
+
+export default function WelcomeSection() {
+  return (
+    <div className='relative flex flex-col items-center justify-between overflow-hidden rounded-lg bg-purple-100 p-6 shadow-sm md:flex-row md:p-8'>
+      <div className='z-10 flex flex-col items-center text-center md:items-start md:text-left'>
+        <h2 className='mb-2 text-2xl font-bold text-gray-900 md:text-3xl'>안녕하세요, 김민수님!</h2>
+        <p className='mb-6 text-lg text-gray-700 md:text-xl'>오늘은 어떤 음악을 발견하고 싶으신가요?</p>
+        <CreatePlaylistButton showText isPrimary>
+          플레이리스트 만들기
+        </CreatePlaylistButton>
+      </div>
+
+      <div className='hidden items-center justify-center md:ml-auto md:flex'>
+        <div className='bg-primary/30 flex h-32 w-32 items-center justify-center rounded-lg'>
+          <Music className='text-primary h-16 w-16' />
+        </div>
+      </div>
+
+      {/* Mobile specific icon */}
+      <div className='mt-6 md:hidden'>
+        <div className='bg-primary/30 flex h-24 w-24 items-center justify-center rounded-lg'>
+          <Music className='text-primary h-12 w-12' />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/WelcomeSection.tsx
+++ b/src/components/dashboard/WelcomeSection.tsx
@@ -2,12 +2,17 @@
 
 import { Music } from 'lucide-react';
 import { CreatePlaylistButton } from '@/components/ui/create-playlist-button';
+import React, { useContext } from 'react';
+import { UserContext } from '@/context/user-context';
 
 export default function WelcomeSection() {
+  const userContext = useContext(UserContext);
+  const userName = userContext?.userName || '사용자';
+
   return (
     <div className='relative flex flex-col items-center justify-between overflow-hidden rounded-lg bg-purple-100 p-6 shadow-sm md:flex-row md:p-8'>
       <div className='z-10 flex flex-col items-center text-center md:items-start md:text-left'>
-        <h2 className='mb-2 text-2xl font-bold text-gray-900 md:text-3xl'>안녕하세요, 김민수님!</h2>
+        <h2 className='mb-2 text-2xl font-bold text-gray-900 md:text-3xl'>안녕하세요, {userName}님!</h2>
         <p className='mb-6 text-lg text-gray-700 md:text-xl'>오늘은 어떤 음악을 발견하고 싶으신가요?</p>
         <CreatePlaylistButton showText isPrimary>
           플레이리스트 만들기

--- a/src/components/ui/Logo.tsx
+++ b/src/components/ui/Logo.tsx
@@ -1,19 +1,93 @@
 import { Music } from 'lucide-react';
 import Link from 'next/link';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
 
-export default function Logo() {
+const logoVariants = cva('text-center', {
+  variants: {
+    size: {
+      sm: '',
+      md: '',
+      lg: '',
+    },
+  },
+  defaultVariants: {
+    size: 'lg',
+  },
+});
+
+const containerVariants = cva('flex items-center justify-center rounded-xl bg-gradient-to-br from-[#2d006b] via-[#6d28d9] to-[#a78bfa] shadow-2xl transition-shadow group-hover:shadow-purple-700/50', {
+  variants: {
+    size: {
+      sm: 'h-8 w-8',
+      md: 'h-10 w-10',
+      lg: 'h-12 w-12',
+    },
+  },
+  defaultVariants: {
+    size: 'lg',
+  },
+});
+
+const iconVariants = cva('text-white', {
+  variants: {
+    size: {
+      sm: 'h-4 w-4',
+      md: 'h-5 w-5',
+      lg: 'h-6 w-6',
+    },
+  },
+  defaultVariants: {
+    size: 'lg',
+  },
+});
+
+const dotVariants = cva('absolute animate-pulse rounded-full bg-pink-500 shadow-lg', {
+  variants: {
+    size: {
+      sm: 'h-2 w-2 -top-0.5 -right-0.5',
+      md: 'h-3 w-3 -top-0.5 -right-0.5',
+      lg: 'h-4 w-4 -top-1 -right-1',
+    },
+  },
+  defaultVariants: {
+    size: 'lg',
+  },
+});
+
+const textVariants = cva('bg-gradient-to-r from-[#2d006b] via-[#6d28d9] to-[#a78bfa] bg-clip-text font-bold text-transparent drop-shadow', {
+  variants: {
+    size: {
+      sm: 'text-lg',
+      md: 'text-2xl',
+      lg: 'text-3xl',
+    },
+  },
+  defaultVariants: {
+    size: 'lg',
+  },
+});
+
+interface LogoProps extends VariantProps<typeof logoVariants> {
+  className?: string;
+  showText?: boolean;
+}
+
+export default function Logo({ className, size = 'lg', showText = true }: LogoProps) {
   return (
-    <div className='text-center'>
+    <div className={cn(logoVariants({ size }), className)}>
       <Link href='/' className='group inline-flex items-center space-x-3'>
         <div className='relative'>
-          <div className='flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-[#2d006b] via-[#6d28d9] to-[#a78bfa] shadow-2xl transition-shadow group-hover:shadow-purple-700/50'>
-            <Music className='h-6 w-6 text-white' />
+          <div className={containerVariants({ size })}>
+            <Music className={iconVariants({ size })} />
           </div>
-          <div className='absolute -top-1 -right-1 h-4 w-4 animate-pulse rounded-full bg-pink-500 shadow-lg'></div>
+          <div className={dotVariants({ size })} />
         </div>
-        <div>
-          <span className='bg-gradient-to-r from-[#2d006b] via-[#6d28d9] to-[#a78bfa] bg-clip-text text-3xl font-bold text-transparent drop-shadow'>MyPly</span>
-        </div>
+        {showText && (
+          <div>
+            <span className={textVariants({ size })}>MyPly</span>
+          </div>
+        )}
       </Link>
     </div>
   );

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+
+import { cn } from "@/lib/utils"
+
+function Avatar({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root>) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      className={cn(
+        "relative flex size-8 shrink-0 overflow-hidden rounded-full",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn("aspect-square size-full", className)}
+      {...props}
+    />
+  )
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "bg-muted flex size-full items-center justify-center rounded-full",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Avatar, AvatarImage, AvatarFallback }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/create-playlist-button.tsx
+++ b/src/components/ui/create-playlist-button.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import Link from 'next/link';
+import { Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import * as React from 'react';
+
+interface CreatePlaylistButtonProps extends React.ComponentPropsWithoutRef<typeof Button> {
+  className?: string;
+  onClick?: () => void;
+  showText?: boolean;
+  isPrimary?: boolean;
+}
+
+export function CreatePlaylistButton({ className, onClick, showText = false, isPrimary = false, children, ...props }: CreatePlaylistButtonProps) {
+  const buttonSize = isPrimary ? 'lg' : showText ? 'default' : 'icon';
+  const buttonVariant = isPrimary ? 'default' : 'ghost';
+
+  return (
+    <Button
+      variant={buttonVariant}
+      size={buttonSize}
+      className={cn(
+        isPrimary ? 'bg-purple-600 px-5 py-2.5 text-white transition-colors hover:bg-purple-700 active:bg-purple-800' : 'bg-primary/10 text-primary',
+        showText && !isPrimary && 'w-full justify-start',
+        className,
+      )}
+      asChild
+      onClick={onClick}
+      {...props}
+    >
+      <Link href='/create'>
+        <Plus className={cn('h-5 w-5', (showText || isPrimary) && 'mr-2')} />
+        {(showText || isPrimary) && (children || '새 플레이리스트')}
+      </Link>
+    </Button>
+  );
+}

--- a/src/constants/quick-actions.tsx
+++ b/src/constants/quick-actions.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { Disc, Headphones, Music, Clock, LucideIcon } from 'lucide-react';
+
+export interface QuickActionItem {
+  title: string;
+  icon: React.ReactElement<LucideIcon>;
+  href: string;
+}
+
+export const quickActions: QuickActionItem[] = [
+  {
+    title: '아티스트별',
+    icon: <Music className='text-primary h-5 w-5' />,
+    href: '/create?type=artist',
+  },
+  {
+    title: '장르별',
+    icon: <Disc className='text-primary h-5 w-5' />,
+    href: '/create?type=genre',
+  },
+  {
+    title: '분위기별',
+    icon: <Headphones className='text-primary h-5 w-5' />,
+    href: '/create?type=mood',
+  },
+  {
+    title: '시대별',
+    icon: <Clock className='text-primary h-5 w-5' />,
+    href: '/create?type=era',
+  },
+];

--- a/src/context/user-context.tsx
+++ b/src/context/user-context.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import React, { createContext, useContext } from 'react';
+
+interface UserContextType {
+  userName: string;
+}
+
+export const UserContext = createContext<UserContextType | undefined>(undefined);
+
+interface UserProviderProps {
+  children: React.ReactNode;
+  userName: string;
+}
+
+export function UserProvider({ children, userName }: UserProviderProps) {
+  return <UserContext.Provider value={{ userName }}>{children}</UserContext.Provider>;
+}
+
+export function useUser() {
+  const context = useContext(UserContext);
+  if (context === undefined) {
+    throw new Error('useUser must be used within a UserProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## 🏷️ 타입
- [x] ✨ Feature 
- [ ] 🐛 Bug
- [ ] ♻️ Refactor
- [ ] 📝 Docs
- [x] 💄 Style
- [ ] 🔧 Chore

## ❓ 관련 이슈
- close #6

## ✍️ 변경사항
<!-- 무엇을 했는지 간단히 작성 -->
- 대시보드 메인 페이지 UI 구성
- 새 플레이리스트 생성 버튼 컴포넌트화
- 개인화된 환영 메시지 표시
- 최근 생성 플레이리스트 표시(임시)
- 4가지 생성 방식 접근 표시

## 📸 스크린샷 (UI 변경시)
<!-- Before/After -->
<img width="1470" alt="스크린샷 2025-06-11 14 08 32" src="https://github.com/user-attachments/assets/5dad32b6-c21d-4aff-81d1-8d0a4fc4f771" />
<img width="481" alt="스크린샷 2025-06-11 14 09 52" src="https://github.com/user-attachments/assets/64f302cc-e1b0-4093-a9a5-e9321a33afb9" />

## ✅ 확인사항
- [x] 로컬 동작 확인
- [x] 린트/타입 에러 없음
- [x] 불필요한 코드 정리

## 📝 메모
<!-- 나중에 참고할 점이나 알아둘 것 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
    - 대시보드에 헤더, 환영 섹션, 빠른 액션, 최근 플레이리스트, 하단 섹션 등 다양한 UI 컴포넌트가 추가되어 더욱 풍부한 대시보드 화면 제공
    - 모바일 환경을 위한 전용 네비게이션(MobileNav) 및 반응형 사이드바 적용
    - 빠른 플레이리스트 생성, 최근 플레이리스트 확인 등 주요 액션을 한눈에 확인 가능
    - 사용자 이름 기반 환영 메시지 및 사용자 정보 컨텍스트 제공
    - 새로운 UI 컴포넌트(아바타, 배지, 플레이리스트 생성 버튼 등) 추가

- **스타일**
    - 로고 컴포넌트가 다양한 크기와 옵션을 지원하도록 개선
    - 반응형 레이아웃 및 스타일링 개선

- **기타**
    - 외부 UI 라이브러리 및 컴포넌트 의존성 추가 (`@radix-ui/react-avatar` 등)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->